### PR TITLE
unify arsenic threshold rule

### DIFF
--- a/app/lab_pipeline.py
+++ b/app/lab_pipeline.py
@@ -12,8 +12,10 @@ def predict_bio_process(s_sulfuro_pct: float, as_ppm: float) -> Dict[str, str]:
     # BIOX recommended
     if s_sulfuro_pct > 1 and (as_ppm is None or as_ppm < 500):
         return {"recommendation": "BIOX"}
-    # High arsenic risk -> consider biolixiviación
-    if as_ppm is not None and as_ppm >= 500:
+    # High arsenic risk -> consider biolixiviación.
+    # Business rule: only values above 500 ppm trigger this path; 500 ppm is treated
+    # as a borderline case and falls through to the default recommendation.
+    if as_ppm is not None and as_ppm > 500:
         return {"recommendation": "Biolixiviación"}
     # Default case: preconcentración o biolixiviación
     return {"recommendation": "Preconcentración o biolixiviación"}

--- a/utils/rules.py
+++ b/utils/rules.py
@@ -16,7 +16,7 @@ def recommend_process(s_sulfuro_pct: Optional[float], as_ppm: Optional[float]) -
     - Si `s_sulfuro_pct` es mayor que 1 % y `as_ppm` es nulo o menor a 500 ppm,
       se recomienda un proceso de oxidación biológica (BIOX).
     - Si `as_ppm` es mayor a 500 ppm se sugiere analizar riesgos de arsénico y
-      considerar biolixiviación.
+      considerar biolixiviación (500 ppm se trata como valor límite).
     - En cualquier otro caso se recomienda preconcentración o biolixiviación.
 
     :param s_sulfuro_pct: Porcentaje de azufre en fase sulfuro (0–100)
@@ -31,6 +31,7 @@ def recommend_process(s_sulfuro_pct: Optional[float], as_ppm: Optional[float]) -
         return "BIOX"
 
     # Riesgo de arsénico elevado
+    # Se aplica un umbral estricto: solo valores mayores a 500 ppm activan la regla.
     if as_ppm is not None and as_ppm > 500:
         return "Revisar riesgo de arsénico y considerar biolixiviación"
 


### PR DESCRIPTION
## Summary
- apply strict `>500 ppm` threshold for arsenic risk in pipeline and rules
- document that 500 ppm is treated as a borderline value

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bf82c8079c832f9c959c34935560ae