### PR TITLE
feat: add prediction monitoring log and dashboard

### DIFF
--- a/dashboard/app.py
+++ b/dashboard/app.py
@@ -1,19 +1,94 @@
-"""Simple Streamlit dashboard for monitoring metrics."""
+"""Streamlit dashboard for inspecting prediction logs."""
 from __future__ import annotations
 
+import os
+import json
 from pathlib import Path
+from datetime import date
 
 import pandas as pd
 import streamlit as st
 
-st.title("Monitoring Dashboard")
+LOG_FILE = Path("monitoring/predictions_log.csv")
 
-metrics_file = Path("monitoring/metrics.csv")
-if metrics_file.exists():
-    df = pd.read_csv(metrics_file)
-    if not df.empty:
-        st.line_chart(df.set_index(df.columns[0]))
+
+def _authenticate() -> None:
+    """Simple username/password gate using environment variables."""
+    user = os.getenv("DASHBOARD_USER", "admin")
+    password = os.getenv("DASHBOARD_PASS", "secret")
+
+    if "auth" not in st.session_state:
+        st.session_state.auth = False
+
+    if st.session_state.auth:
+        return
+
+    st.sidebar.subheader("Login")
+    u = st.sidebar.text_input("User")
+    p = st.sidebar.text_input("Password", type="password")
+    if st.sidebar.button("Login") and u == user and p == password:
+        st.session_state.auth = True
     else:
-        st.info("Metrics file is empty.")
-else:
-    st.info("No metrics available yet. Populate 'monitoring/metrics.csv' to see plots.")
+        st.stop()
+
+
+def _load_logs() -> pd.DataFrame:
+    if not LOG_FILE.exists():
+        return pd.DataFrame(columns=[
+            "timestamp",
+            "batch",
+            "input",
+            "prediction",
+            "outcome",
+            "improvement",
+        ])
+    df = pd.read_csv(LOG_FILE)
+    if df.empty:
+        return df
+    df["timestamp"] = pd.to_datetime(df["timestamp"])
+    df["input"] = df["input"].apply(json.loads)
+    return df
+
+
+def main() -> None:
+    _authenticate()
+    st.title("Monitoring Dashboard")
+
+    df = _load_logs()
+    if df.empty:
+        st.info("No logs available yet.")
+        return
+
+    batches = ["All"] + sorted(df["batch"].dropna().unique().tolist())
+    batch = st.sidebar.selectbox("Batch", batches)
+    start = st.sidebar.date_input("Start", df["timestamp"].min().date())
+    end = st.sidebar.date_input("End", df["timestamp"].max().date())
+
+    mask = (df["timestamp"].dt.date >= start) & (df["timestamp"].dt.date <= end)
+    if batch != "All":
+        mask &= df["batch"] == batch
+
+    filtered = df[mask]
+
+    st.subheader("Recent entries")
+    st.dataframe(filtered.sort_values("timestamp", ascending=False).head(100))
+
+    if filtered["outcome"].notna().any():
+        st.subheader("Prediction vs Outcome")
+        chart_df = filtered.set_index("timestamp")[
+            ["prediction", "outcome"]
+        ]
+        st.line_chart(chart_df)
+    else:
+        st.info("No outcome data to plot.")
+
+    if filtered["improvement"].notna().any():
+        st.subheader("Uplift over time")
+        uplift_df = filtered.set_index("timestamp")["improvement"]
+        st.line_chart(uplift_df)
+    else:
+        st.info("No improvement data to plot.")
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/monitoring/__init__.py
+++ b/monitoring/__init__.py
@@ -1,0 +1,5 @@
+"""Monitoring utilities."""
+
+from .log import log_event
+
+__all__ = ["log_event"]

--- a/monitoring/log.py
+++ b/monitoring/log.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+"""Utility for logging prediction outcomes for monitoring."""
+
+from pathlib import Path
+import csv
+import json
+from datetime import datetime
+from typing import Any, Dict, Optional
+
+# Path to the structured log file
+LOG_FILE = Path(__file__).with_name("predictions_log.csv")
+
+# Columns stored in the log
+FIELDNAMES = [
+    "timestamp",
+    "batch",
+    "input",
+    "prediction",
+    "outcome",
+    "improvement",
+]
+
+
+def log_event(
+    input_data: Dict[str, Any],
+    prediction: float,
+    outcome: Optional[float] = None,
+    improvement: Optional[float] = None,
+    batch: Optional[str] = None,
+) -> None:
+    """Append a prediction event to the structured log.
+
+    Parameters
+    ----------
+    input_data: dict
+        Features sent to the model.
+    prediction: float
+        Model prediction.
+    outcome: float, optional
+        Real outcome observed. If provided and ``improvement`` is not
+        specified, the improvement is computed as ``outcome - prediction``.
+    improvement: float, optional
+        Uplift obtained from the prediction.
+    batch: str, optional
+        Identifier for the batch or lot.
+    """
+
+    if improvement is None and outcome is not None:
+        improvement = outcome - prediction
+
+    record = {
+        "timestamp": datetime.utcnow().isoformat(),
+        "batch": batch,
+        "input": json.dumps(input_data, sort_keys=True),
+        "prediction": prediction,
+        "outcome": outcome,
+        "improvement": improvement,
+    }
+
+    exists = LOG_FILE.exists()
+    with LOG_FILE.open("a", newline="") as fh:
+        writer = csv.DictWriter(fh, fieldnames=FIELDNAMES)
+        if not exists:
+            writer.writeheader()
+        writer.writerow(record)


### PR DESCRIPTION
## Summary
- log inference requests and outcomes to `monitoring/predictions_log.csv`
- show recent predictions, prediction vs outcome and uplift charts with filters in dashboard
- require simple login for dashboard access

## Testing
- `python -m py_compile monitoring/log.py monitoring/__init__.py inference/serve.py dashboard/app.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c2018a2a94832fa0ac70192e58c622